### PR TITLE
Implement upgrade libraries

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -6,8 +6,7 @@
   "packages": {
     "node_modules/@actions/core": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "license": "MIT",
       "dependencies": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"
@@ -15,50 +14,42 @@
     },
     "node_modules/@actions/http-client": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
-      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6"
       }
     },
     "node_modules/asn1": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "license": "MIT"
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "license": "MIT"
     },
     "node_modules/buildcheck": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
-      "integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
@@ -66,19 +57,17 @@
     },
     "node_modules/commander": {
       "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "engines": [
         "node >= 6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -88,8 +77,6 @@
     },
     "node_modules/cpu-features": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
-      "integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -102,12 +89,11 @@
     },
     "node_modules/err-code": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+      "license": "MIT"
     },
     "node_modules/ftp-deployment": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/saucal/ftp-deployment.git#f0f7c881ab601dc44be536d52112684befd57693",
+      "resolved": "git+ssh://git@github.com/saucal/ftp-deployment.git#4e7db589d7e0b68650be0463ae4a979bc58ac790",
       "license": "ISC",
       "dependencies": {
         "commander": "^9.3.0",
@@ -120,13 +106,11 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -136,14 +120,12 @@
     },
     "node_modules/nan": {
       "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -154,8 +136,7 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -167,16 +148,13 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -190,17 +168,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "license": "MIT"
     },
     "node_modules/ssh2": {
       "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
-      "integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
       "hasInstallScript": true,
       "dependencies": {
         "asn1": "^0.2.4",
@@ -216,8 +192,7 @@
     },
     "node_modules/ssh2-sftp-client": {
       "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-9.0.4.tgz",
-      "integrity": "sha512-fHAXUgmtmqUq/IdMlN9DBhkzrRFQRfORsQYglZMdnvosr4oo/6js+jxrJgGU+alNLW8ZN1IZFfRSoAejyvr8zg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "concat-stream": "^2.0.0",
         "promise-retry": "^2.0.1",
@@ -229,39 +204,33 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+      "license": "Unlicense"
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/node_modules/ftp-deployment/client.js
+++ b/node_modules/ftp-deployment/client.js
@@ -10,6 +10,12 @@ class ftpClient {
 	constructor(config) {
 		this.connected = -1;
 		this.config = config
+		this.queue = {
+			'*': [], // create path
+			'+': [], // upload
+			'-': [], // remove file
+			'_': [], // maybe cleanup path
+		}
 
 		console.log(config);
 		switch( this.config.type ) {
@@ -101,14 +107,15 @@ class ftpClient {
 				}
 			} )
 			.then( function() {
+				if( recursive !== true ) {
+					return self.voidPromise();
+				}
 				const paths = self.leadingPaths( fileOrDir );
 				if( paths.length > 0 ) {
 					return self.rmdirIfEmpty( path.dirname( fileOrDir ) );
 				} else {
 					return self.voidPromise();
 				}
-				// TODO: Delete all directories up to this file which are empty. Replicate GIT strcuture
-				return self.voidPromise();
 			} );
 	}
 
@@ -166,9 +173,9 @@ class ftpClient {
 			})
 	}
 
-	rmdirIfEmpty( dirPath ) {
+	rmdirIfEmpty( dirPath, recursive = true ) {
 		const self = this;
-		const paths = self.leadingPaths( dirPath ).reverse();
+		const paths = recursive ? self.leadingPaths( dirPath ).reverse() : [ dirPath ];
 		return self
 			.maybeConnect()
 			.then( function() {
@@ -176,21 +183,36 @@ class ftpClient {
 				paths.forEach( function( thisPath ) {
 					let remoteFullPath = path.join( self.config.remoteRoot, thisPath );
 					chain = chain.then(function() {
-						return self.client
-							.exists( remoteFullPath )
-							.then( function( exists ) {
-								switch ( exists ) {
-									case 'd':
-										return self.client
-											.list( remoteFullPath )
-											.then( function( data ){
-												console.log( 'rmdir: ' + remoteFullPath );
-												if ( data.length === 0 ) {
-													return self.client.rmdir( remoteFullPath );
-												}
-											} )
-								}
-							} )
+						switch( self.config.type ) {
+							case 'void':
+								console.log( 'exist', remoteFullPath );
+								return self.voidPromise().then(function(){
+									console.log( 'list', remoteFullPath );
+									return self.voidPromise().then(function(){
+										console.log( 'rmdir', remoteFullPath );
+										return self.voidPromise()
+									})
+								});
+							default:
+								console.log( 'exist: ' + remoteFullPath );
+								return self.client
+									.exists( remoteFullPath )
+									.then( function( exists ) {
+										switch ( exists ) {
+											case 'd':
+												console.log( 'list: ' + remoteFullPath );
+												return self.client
+													.list( remoteFullPath )
+													.then( function( data ){
+														console.log( 'rmdir: ' + remoteFullPath );
+														if ( data.length === 0 ) {
+															return self.client.rmdir( remoteFullPath );
+														}
+													} )
+										}
+									} )
+						}
+						
 					} );
 				} );
 
@@ -275,15 +297,74 @@ class ftpClient {
 			}  );
 
 			rl.on( 'close', function() {
-				chain = chain.then( function() {
+				chain = chain.then(function(){
+					return self.processQueue();	
+				}).then( function() {
 					resolve();
 				} );
 			} );
 		})
 	}
 
+	processQueue() {
+		const self = this;
+		return new Promise( function( resolve, reject ) {
+			self.sortQueue('*');
+			self.sortQueue('+');
+			self.sortQueue('-');
+			self.sortQueue('_', false );
+			let chain = self.voidPromise();
+
+			self.queue['*'].forEach(function(item){
+				chain = chain.then( function() { 
+					return self.mkdirp( item )
+				} );
+			});
+			self.queue['+'].forEach(function(item){
+				chain = chain.then( function() {
+					return self.put( item, false )
+				} );
+			});
+			self.queue['-'].forEach(function(item){
+				chain = chain.then( function() {
+					return self.rm( item, false )
+				} );
+			});
+			self.queue['_'].forEach(function(item){
+				chain = chain.then( function() {
+					return self.rmdirIfEmpty( item, false )
+				} );
+			});
+			chain.then( function() {
+				resolve();
+			});
+		} );
+	}
+
+	pushToQueue( action, path ) {
+		var self = this;
+		if( self.queue[action].indexOf( path ) === -1 ) {
+			self.queue[action].push(path)
+		}
+	}
+
+	sortQueue( action, asc = true ) {
+		var self = this;
+		self.queue[action].sort( function( a, b ) {
+			var aLen = (a.match(/\//g) || []).length
+			var bLen = (b.match(/\//g) || []).length
+			if( asc ) {
+				return aLen - bLen || a.localeCompare(b);
+			} else {
+				return bLen - aLen || a.localeCompare(b);
+			}
+		} )
+	}
+
 	handleProcessLine( line, config ) {
-		var path = line.substr( 2 );
+		var self = this;
+		var file = line.substr( 2 );
+		var dir = path.dirname( file );
 		var action = line.substr( 0, 1 );
 
 		for ( let i in config.ignore ) {
@@ -294,10 +375,18 @@ class ftpClient {
 			}
 		}
 
-		if ( '-' === action ) {
-			return this.rm( path, true );
-		} else {
-			return this.put( path, true );
+		if( '+' == action ) {
+			while ( '.' !== dir ) {
+				self.pushToQueue( '*', dir );
+				dir = path.dirname(dir);
+			}
+			self.pushToQueue( '+', file );
+		} else if( '-' == action ) {
+			while ( '.' !== dir ) {
+				self.pushToQueue( '_', dir );
+				dir = path.dirname(dir);
+			}
+			self.pushToQueue( '-', file );
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
 		},
 		"node_modules/@actions/core": {
 			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+			"license": "MIT",
 			"dependencies": {
 				"@actions/http-client": "^2.0.1",
 				"uuid": "^8.3.2"
@@ -27,50 +26,42 @@
 		},
 		"node_modules/@actions/http-client": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
-			"integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+			"license": "MIT",
 			"dependencies": {
 				"tunnel": "^0.0.6"
 			}
 		},
 		"node_modules/asn1": {
 			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": "~2.1.0"
 			}
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"license": "MIT"
 		},
 		"node_modules/bcrypt-pbkdf": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tweetnacl": "^0.14.3"
 			}
 		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+			"license": "MIT"
 		},
 		"node_modules/buildcheck": {
 			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
-			"integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
 			"optional": true,
 			"engines": {
 				"node": ">=10.0.0"
@@ -78,19 +69,17 @@
 		},
 		"node_modules/commander": {
 			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-			"integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || >=14"
 			}
 		},
 		"node_modules/concat-stream": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-			"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
 			"engines": [
 				"node >= 6.0"
 			],
+			"license": "MIT",
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -100,8 +89,6 @@
 		},
 		"node_modules/cpu-features": {
 			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
-			"integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -114,12 +101,11 @@
 		},
 		"node_modules/err-code": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+			"license": "MIT"
 		},
 		"node_modules/ftp-deployment": {
 			"version": "1.0.0",
-			"resolved": "git+ssh://git@github.com/saucal/ftp-deployment.git#f0f7c881ab601dc44be536d52112684befd57693",
+			"resolved": "git+ssh://git@github.com/saucal/ftp-deployment.git#4e7db589d7e0b68650be0463ae4a979bc58ac790",
 			"license": "ISC",
 			"dependencies": {
 				"commander": "^9.3.0",
@@ -132,13 +118,11 @@
 		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"license": "ISC"
 		},
 		"node_modules/minimatch": {
 			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-			"integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -148,14 +132,12 @@
 		},
 		"node_modules/nan": {
 			"version": "2.17.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/promise-retry": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+			"license": "MIT",
 			"dependencies": {
 				"err-code": "^2.0.2",
 				"retry": "^0.12.0"
@@ -166,8 +148,7 @@
 		},
 		"node_modules/readable-stream": {
 			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -179,16 +160,13 @@
 		},
 		"node_modules/retry": {
 			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -202,17 +180,15 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "MIT"
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"license": "MIT"
 		},
 		"node_modules/ssh2": {
 			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
-			"integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"asn1": "^0.2.4",
@@ -228,8 +204,7 @@
 		},
 		"node_modules/ssh2-sftp-client": {
 			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-9.0.4.tgz",
-			"integrity": "sha512-fHAXUgmtmqUq/IdMlN9DBhkzrRFQRfORsQYglZMdnvosr4oo/6js+jxrJgGU+alNLW8ZN1IZFfRSoAejyvr8zg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"concat-stream": "^2.0.0",
 				"promise-retry": "^2.0.1",
@@ -241,39 +216,33 @@
 		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/tunnel": {
 			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.6.11 <=0.7.0 || >=0.7.3"
 			}
 		},
 		"node_modules/tweetnacl": {
 			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+			"license": "Unlicense"
 		},
 		"node_modules/typedarray": {
 			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+			"license": "MIT"
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+			"license": "MIT"
 		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"license": "MIT",
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
@@ -282,8 +251,6 @@
 	"dependencies": {
 		"@actions/core": {
 			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
 			"requires": {
 				"@actions/http-client": "^2.0.1",
 				"uuid": "^8.3.2"
@@ -291,61 +258,43 @@
 		},
 		"@actions/http-client": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
-			"integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
 			"requires": {
 				"tunnel": "^0.0.6"
 			}
 		},
 		"asn1": {
 			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
 		},
 		"balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"version": "1.0.2"
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
 		},
 		"brace-expansion": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"requires": {
 				"balanced-match": "^1.0.0"
 			}
 		},
 		"buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+			"version": "1.1.2"
 		},
 		"buildcheck": {
 			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
-			"integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
 			"optional": true
 		},
 		"commander": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-			"integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw=="
+			"version": "9.4.1"
 		},
 		"concat-stream": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-			"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -355,8 +304,6 @@
 		},
 		"cpu-features": {
 			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
-			"integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
 			"optional": true,
 			"requires": {
 				"buildcheck": "0.0.3",
@@ -364,12 +311,10 @@
 			}
 		},
 		"err-code": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+			"version": "2.0.3"
 		},
 		"ftp-deployment": {
-			"version": "git+ssh://git@github.com/saucal/ftp-deployment.git#f0f7c881ab601dc44be536d52112684befd57693",
+			"version": "git+ssh://git@github.com/saucal/ftp-deployment.git#4e7db589d7e0b68650be0463ae4a979bc58ac790",
 			"from": "ftp-deployment@github:saucal/ftp-deployment",
 			"requires": {
 				"commander": "^9.3.0",
@@ -378,28 +323,20 @@
 			}
 		},
 		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"version": "2.0.4"
 		},
 		"minimatch": {
 			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-			"integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
 			"requires": {
 				"brace-expansion": "^2.0.1"
 			}
 		},
 		"nan": {
 			"version": "2.17.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
 			"optional": true
 		},
 		"promise-retry": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
 			"requires": {
 				"err-code": "^2.0.2",
 				"retry": "^0.12.0"
@@ -407,8 +344,6 @@
 		},
 		"readable-stream": {
 			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 			"requires": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -416,24 +351,16 @@
 			}
 		},
 		"retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
+			"version": "0.12.0"
 		},
 		"safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+			"version": "5.2.1"
 		},
 		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"version": "2.1.2"
 		},
 		"ssh2": {
 			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
-			"integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
 			"requires": {
 				"asn1": "^0.2.4",
 				"bcrypt-pbkdf": "^1.0.2",
@@ -443,8 +370,6 @@
 		},
 		"ssh2-sftp-client": {
 			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-9.0.4.tgz",
-			"integrity": "sha512-fHAXUgmtmqUq/IdMlN9DBhkzrRFQRfORsQYglZMdnvosr4oo/6js+jxrJgGU+alNLW8ZN1IZFfRSoAejyvr8zg==",
 			"requires": {
 				"concat-stream": "^2.0.0",
 				"promise-retry": "^2.0.1",
@@ -453,36 +378,24 @@
 		},
 		"string_decoder": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 			"requires": {
 				"safe-buffer": "~5.2.0"
 			}
 		},
 		"tunnel": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+			"version": "0.0.6"
 		},
 		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+			"version": "0.14.5"
 		},
 		"typedarray": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+			"version": "0.0.6"
 		},
 		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+			"version": "1.0.2"
 		},
 		"uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+			"version": "8.3.2"
 		}
 	}
 }


### PR DESCRIPTION
Update ftp-deployment code to better organize the manifest and process it more orgnized.

Previous version was attempting to remove a potential empty directory structure after removing each file. Now that process is done in an organized way at the end of the process, and avoiding a very dangerous amount of unnecessary operations.

Even tho we're still relying on a single connection, with this, we should be avoiding like 80% (if not more) of unnecessary requests in uploads that had a lot of file removals on them (typical on maintenances).